### PR TITLE
Fixing bug with operator not being able to recover from BlockedStatus…

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -656,6 +656,62 @@ access_control:
 
     @patch("subprocess.run")
     @patch("netifaces.interfaces")
+    @patch("charm.open", new_callable=mock_open, read_data=TEST_PIPELINED_CONFIG)
+    def test_given_block_agw_local_ips_config_is_false_when_install_then_unblock_local_ips_flag_is_added_to_the_snap_installation_command(  # noqa: E501
+        self, _, patch_interfaces, patch_subprocess_run
+    ):
+        event = Mock()
+        patch_interfaces.return_value = ["enp0s1", "enp0s2"]
+        patch_subprocess_run.side_effect = [
+            Mock(returncode=1),
+            Mock(returncode=0),
+            Mock(returncode=0),
+            Mock(returncode=0),
+            Mock(returncode=0),
+        ]
+        self.harness.update_config(
+            {
+                "sgi": "enp0s1",
+                "s1": "enp0s2",
+                "block-agw-local-ips": False,
+            }
+        )
+        patch_subprocess_run.assert_has_calls(
+            [
+                call(["systemctl", "is-enabled", "magma@magmad"], stdout=-1),
+                call(
+                    [
+                        "snap",
+                        "install",
+                        "magma-access-gateway",
+                        "--classic",
+                        "--channel",
+                        "1.8/stable",
+                    ],
+                    stdout=-1,
+                ),
+                call(
+                    [
+                        "magma-access-gateway.install",
+                        "--no-reboot",
+                        "--dns",
+                        "8.8.8.8",
+                        "208.67.222.222",
+                        "--unblock-local-ips",
+                        "--sgi",
+                        "enp0s1",
+                        "--s1",
+                        "enp0s2",
+                    ],
+                    stdout=-1,
+                ),
+                call(["shutdown", "--reboot", "+1"], stdout=-1),
+            ]
+        )
+        self.charm._on_install(event=event)
+
+    @patch("subprocess.run")
+    @patch("netifaces.interfaces")
     def test_given_magma_service_not_running_when_start_then_status_is_unchanged(
         self, _, patch_subprocess_run
     ):


### PR DESCRIPTION
… caused by invalid configuration

# Description

- Fixes operator not being able to recover from BlockedStatus caused by invalid configuration. After the change, on ConfigChangedEvent, operator will reattempt the installation process if magmad service is not running.
- Adjusts the operator's code to the [changes in the snap](https://github.com/canonical/magma-access-gateway-snap/pull/48)

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.